### PR TITLE
Transcoder.register() takes instance of custom transcoding, not Class

### DIFF
--- a/docs/topics/application.rst
+++ b/docs/topics/application.rst
@@ -623,7 +623,7 @@ method once for each of your custom transcodings.
     class MyApplication(Application):
         def register_transcodings(self, transcoder: Transcoder):
             super().register_transcodings(transcoder)
-            transcoder.register(DateAsISO)
+            transcoder.register(DateAsISO())
 
 
     class DateAsISO(Transcoding):


### PR DESCRIPTION
Think the example is missing parentheses on the end of `DateAsISO`.  As it stands, the code is passing the Class; whereas `Transcoder.register()` takes an instance.  Haven't tried with the specific example code but have erified with a different custom transcoding.