### PR TITLE
Docs/sf review

### DIFF
--- a/docs/topics/tutorial/part1.rst
+++ b/docs/topics/tutorial/part1.rst
@@ -135,8 +135,8 @@ As above, we can call the method ``add_trick()``. The given value is appended to
 
     assert dog.tricks == ['roll over']
 
-By redefining the ``Dog`` class as an event-sourced aggregate in this way, we can
-generate a sequence of event objects that can be used to reconstruct the aggregate.
+By redefining the ``Dog`` class as an event-sourced aggregate in this way, we can generate a sequence 
+of event objects that can be recorded and used later to reconstruct the aggregate.
 
 We can get the events from the aggregate by calling ``collect_events()``.
 
@@ -170,7 +170,7 @@ when the copy was taken.  Let's explore that a little:
     assert partial_copy.tricks == []
 
 Here, we've stripped off the last event in ``dog``'s history.  That corresponds to adding the ``roll over`` trick.
-We then use that partial history to create another copy of ``dog``.  We can see that the name is set correctly, but 
+We then use that partial history to create another copy of ``dog``.  We can see that the name is set correctly, but the 
 ``roll over`` trick hasn't been added.
 
 Event sourced aggregates keep a record of history. They're like a built-in Git repository for each aggregate that can be

--- a/docs/topics/tutorial/part1.rst
+++ b/docs/topics/tutorial/part1.rst
@@ -155,28 +155,6 @@ We can then reconstruct the aggregate by calling ``mutate()`` on the collected e
 
     assert copy == dog
 
-Now, at this point, you might reasonably observe that, with conventional code, you would
-simply write ``copy = dog``.  But that wouldn't give us the history; just the current state of ``dog`` 
-when the copy was taken.  Let's explore that a little:
-
-.. code-block:: python
-
-    partial_events = events[:-1]
-    partial_copy = None
-    for e in partial_events:
-        partial_copy = e.mutate(partial_copy)
-    
-    assert dog.name == 'Fido'
-    assert partial_copy.tricks == []
-
-Here, we've stripped off the last event in ``dog``'s history.  That corresponds to adding the ``roll over`` trick.
-We then use that partial history to create another copy of ``dog``.  We can see that the name is set correctly, but the 
-``roll over`` trick hasn't been added.
-
-Event sourced aggregates keep a record of history. They're like a built-in Git repository for each aggregate that can be
-accessed at run time.  At any given point, we can go "back through time" to observe the aggregate's change history.
-For example: imagine a bank acount that carries its transaction history with it.
-
 Event-sourced aggregates can be developed and tested independently.
 
 However, event-sourced aggregates are normally used within an application object, so

--- a/docs/topics/tutorial/part1.rst
+++ b/docs/topics/tutorial/part1.rst
@@ -164,7 +164,7 @@ when the copy was taken.  Let's explore that a little:
     partial_events = events[:-1]
     partial_copy = None
     for e in partial_events:
-        partial_copy = e.mutate(copy)
+        partial_copy = e.mutate(partial_copy)
     
     assert dog.name == 'Fido'
     assert partial_copy.tricks == []
@@ -175,6 +175,7 @@ We then use that partial history to create another copy of ``dog``.  We can see 
 
 Event sourced aggregates keep a record of history. They're like a built-in Git repository for each aggregate that can be
 accessed at run time.  At any given point, we can go "back through time" to observe the aggregate's change history.
+For example: imagine a bank acount that carries its transaction history with it.
 
 Event-sourced aggregates can be developed and tested independently.
 

--- a/docs/topics/tutorial/part1.rst
+++ b/docs/topics/tutorial/part1.rst
@@ -155,6 +155,26 @@ We can then reconstruct the aggregate by calling ``mutate()`` on the collected e
 
     assert copy == dog
 
+Now, at this point, you might reasonably observe that, with conventional code, you would
+simply write ``copy = dog``.  But that wouldn't give us the history; just the current state of ``dog`` 
+when the copy was taken.  Let's explore that a little:
+
+.. code-block:: python
+
+    partial_events = events[:-1]
+    partial_copy = None
+    for e in partial_events:
+        partial_copy = e.mutate(copy)
+    
+    assert dog.name == 'Fido'
+    assert partial_copy.tricks == []
+
+Here, we've stripped off the last event in ``dog``'s history.  That corresponds to adding the ``roll over`` trick.
+We then use that partial history to create another copy of ``dog``.  We can see that the name is set correctly, but 
+``roll over`` trick hasn't been added.
+
+Event sourced aggregates keep a record of history. They're like a built-in Git repository for each aggregate that can be
+accessed at run time.  At any given point, we can go "back through time" to observe the aggregate's change history.
 
 Event-sourced aggregates can be developed and tested independently.
 


### PR DESCRIPTION
Suggestion.  The "so what" of keeping history isn't immediately obvious from the example.  Expanded to make that more explicit.   It's more code, and I know there's a balance between demonstrating features and keeping perspective.  Just felt that making the history explicit was, on balance, beneficial.