### PR TITLE
docs: fix bug/typo in tutorial part 2

### DIFF
--- a/docs/topics/tutorial/part2.rst
+++ b/docs/topics/tutorial/part2.rst
@@ -401,6 +401,7 @@ using the ``trigger_event()`` method defined by the ``Aggregate`` class.
 
             def mutate(self, aggregate):
                 aggregate.tricks.append(self.trick)
+                return aggregate
 
 
 Because the ``trick_added()`` method is not decorated with the ``@event``


### PR DESCRIPTION
The code in the tutorial shows [how to write a command that triggers the event using `trigger_event()`](https://eventsourcing.readthedocs.io/en/stable/topics/tutorial/part2.html#explicit-style) where the `mutate` method is implemented on the event. However, there is a bug in the document as it should return the `aggregate` instance. Otherwise, it is not possible to complete the exercise later on in the tutorial using this explicit approach. 

For example, here's my solution to the exercise:

```py
from eventsourcing.domain import Aggregate, event


class Todos(Aggregate):
    class Started(Aggregate.Created):
        name: str

    @event(Started)
    def __init__(self, name: str):
        self.name = name
        self.items = []

    class ItemAdded(Aggregate.Event):
        item: str

        def mutate(self, aggregate: "Todos"):
            aggregate.items.append(self.item)
            return aggregate  # NOTE: the aggregate must be returned by `mutate`

    def add_item(self, item: str):
        self.trigger_event(self.ItemAdded, item=item)
```

without this, the assertion in the code block below fails because `e.mutate` for the first `TrickAdded` event returns `None` and then the second `TrickAdded` event throws `AttributeError: 'NoneType' object has no attribute 'items'`.

```py
    # Reconstruct aggregate from events.
    copy = None
    for e in events:
        copy = e.mutate(copy)
    assert copy == todos1
```

Also, looking at the function in `CanMutateAggregate::mutate` shows:

```py
    def mutate(self, aggregate: Optional[TAggregate]) -> Optional[TAggregate]:
        """
        Changes the state of the aggregate
        according to domain event attributes.
        """
        assert aggregate is not None
        ...
```

The return value is never `None`. Would it be clearer to make the signature non-optional? 

Alternatively, would the documented usage of `e.mutate` be better expressed where the instance `copy` is mutated, or does this not work with the other styles? i.e.

```py
    # Reconstruct aggregate from events.
    copy = None
    for e in events:
       e.mutate(copy)  # no assignment to copy
    assert copy == todos1
```