### PR TITLE
fix error in notifcation log documentation

### DIFF
--- a/docs/topics/application.rst
+++ b/docs/topics/application.rst
@@ -348,7 +348,7 @@ Selecting notifications from the log
 The :func:`~eventsourcing.application.LocalNotificationLog.select` method of a
 notification log can be used to directly select a sub-sequence of
 :ref:`event notification objects <Notification objects>` from a notification log.
-In the example below, the first three event notifications are selected from the
+In the example below, the first two event notifications are selected from the
 notification log of the ``application`` object.
 
 .. code-block:: python


### PR DESCRIPTION
`notifications = application.notification_log.select(start=1, limit=2)` will call an SQL transaction which uses `LIMIT`, which will only retrieve 2 records instead of 3 stated in the documentation.