### PR TITLE
docs: fix `python -mvenv` typo

### DIFF
--- a/docs/topics/installing.rst
+++ b/docs/topics/installing.rst
@@ -23,7 +23,7 @@ It is recommended to install the library into a Python virtual environment.
 
 ::
 
-    $ python3 -mvenv my_venv
+    $ python3 -m venv my_venv
     $ source my_venv/bin/activate
     (my_venv) $ pip install eventsourcing
 


### PR DESCRIPTION
This is just adding a single space to `python -m venv my_venv` in the installation guide - slightly baffed why this would fail the checks!