### PR TITLE
Requeue notifications backlog on restart

### DIFF
--- a/eventsourcing/system.py
+++ b/eventsourcing/system.py
@@ -1021,7 +1021,7 @@ class PullingThread(Thread):
         try:
             while not self.is_stopping.is_set():
                 if self.recording_event_queue.qsize() == 0 and (
-                    self.follower.recorder.max_notification_id() 
+                    self.follower.recorder.max_notification_id()
                     > self.previous_max_notification_id
                 ):
                     start = self.previous_max_notification_id + 1

--- a/eventsourcing/system.py
+++ b/eventsourcing/system.py
@@ -1020,6 +1020,15 @@ class PullingThread(Thread):
         self.has_started.set()
         try:
             while not self.is_stopping.is_set():
+                if self.follower.recorder.max_notification_id() > self.previous_max_notification_id:
+                    start = self.previous_max_notification_id + 1
+                    stop = self.follower.recorder.max_notification_id()
+                    for notifications in self.follower.pull_notifications(
+                        self.leader_name, start=start, stop=stop
+                    ):
+                        self.converting_queue.put(notifications)
+                        self.previous_max_notification_id = notifications[-1].id
+                    return
                 recording_event = self.recording_event_queue.get()
                 self.recording_event_queue.task_done()
                 if recording_event is None:

--- a/eventsourcing/system.py
+++ b/eventsourcing/system.py
@@ -1020,7 +1020,7 @@ class PullingThread(Thread):
         self.has_started.set()
         try:
             while not self.is_stopping.is_set():
-                if self.follower.recorder.max_notification_id() > self.previous_max_notification_id:
+                if self.recording_event_queue.qsize() == 0 and (self.follower.recorder.max_notification_id() > self.previous_max_notification_id):
                     start = self.previous_max_notification_id + 1
                     stop = self.follower.recorder.max_notification_id()
                     for notifications in self.follower.pull_notifications(

--- a/eventsourcing/system.py
+++ b/eventsourcing/system.py
@@ -1020,7 +1020,10 @@ class PullingThread(Thread):
         self.has_started.set()
         try:
             while not self.is_stopping.is_set():
-                if self.recording_event_queue.qsize() == 0 and (self.follower.recorder.max_notification_id() > self.previous_max_notification_id):
+                if self.recording_event_queue.qsize() == 0 and (
+                    self.follower.recorder.max_notification_id() 
+                    > self.previous_max_notification_id
+                ):
                     start = self.previous_max_notification_id + 1
                     stop = self.follower.recorder.max_notification_id()
                     for notifications in self.follower.pull_notifications(


### PR DESCRIPTION
Please evaluate this update that solves for a case we are seeing on restarts.

When a system restart occurs, there are occasionally some events that remain unprocessed by following applications.  This update attempts to identify that case, and handle it.

The check for the recording_event_queue that now follows, will in this case be empty, as no events have yet been submitted.

